### PR TITLE
Fix catalog link in base2-test_profile.xml

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/base2-test_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/base2-test_profile.xml
@@ -21,7 +21,7 @@
     </import>
     <back-matter>
         <resource id="catalog">
-            <rlink href="abc-simple_catalog.xml"/>
+            <rlink href="catalogs/abc-simple_catalog.xml"/>
         </resource>
     </back-matter>
 </profile>


### PR DESCRIPTION
# Committer Notes
This corrects the resource path to point to the subdirectory location, which is where the reference catalog is located.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?
