### PR TITLE
Fix typo in match part of spec.

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-specml.xml
+++ b/src/specifications/profile-resolution/profile-resolution-specml.xml
@@ -836,7 +836,7 @@
               have related IDs as well.</p>
             
             <tagging whose="source_profile">&lt;include>
-  &lt;call match="^ac"/>&lt;!-- matches any control whose ID matches regex '^ac' -->
+  &lt;match pattern="^ac"/>&lt;!-- matches any control whose ID matches regex '^ac' -->
 &lt;/include>
 </tagging>
             <p><revisit>The match pattern is evaluated as a regular expression using XPath regular


### PR DESCRIPTION
# Committer Notes

This is a minor fix to correct the syntax in the resolver spec that relates to the `match` operation.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
