### PR TITLE
Fix catalog reference in loose param test profile example

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/include-loose-param-test_profile.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/include-loose-param-test_profile.xml
@@ -10,7 +10,7 @@
         <version>1.0</version>
         <oscal-version>1.0-MR2</oscal-version>
     </metadata>
-    <import href="catalogs/abc-simple_catalog.xml">
+    <import href="catalogs/abc-full_catalog.xml">
         <include >
             <!-- a1 includes an insert[@param-id="A.a"], so that parameter should be propagated. -->
             <call control-id="a1"/>


### PR DESCRIPTION
# Committer Notes

Fix path for catalog in loose param example: if its meant to result in a loose param, then it needs to come from `abc-full-catalog.xml` rather than `abc-simple-catalog.xml` (which doesn't have any `<param>`.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
