### PR TITLE
Fix profile resolver results for full-test_profile.xml example

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/full-test_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/full-test_profile_RESOLVED.xml
@@ -8,51 +8,72 @@
       <prop name="resolution-timestamp">2019-12-10T15:21:20.451-05:00</prop>
       <link rel="resolution-source" href="../full-test_profile.xml">Full test Profile</link>
    </metadata>
-   <param id="param-A.a">
-      <label>A.a parameter</label>
-      <value>A.a value</value>
-   </param>
-   <control id="a1">
-      <title>Control A1</title>
-      <param id="param-a1.a">
-         <label>a1.a parameter</label>
-         <value>a1.a value</value>
-      </param>
-      <prop name="place">first</prop>
-      <part name="statement" id="a1-stmt">
-         <p>A1 aaaaa aaaaaaaaaa</p>
-         <p>Parameter A.a is set: <insert param-id="param-A.a"/>
-         </p>
-         <p>Parameter a1.a is set: <insert param-id="param-a1.a"/>
-         </p>
-         <p>Also, we <a href="#citation">refer to a citation</a>.</p>
-      </part>
-   </control>
-   <control id="b1">
-      <title>Control B1</title>
-      <prop name="place">first</prop>
-      <part name="statement" id="b1-stmt">
-         <p>B1 bbbb bbbbbbb.</p>
-      </part>
-   </control>
-   <control id="c1">
-      <title>Control C1</title>
-      <prop name="place">first</prop>
-      <part name="statement" id="c1-stmt">
-         <p>C1 ccccc ccc ccccccccccccccccc.</p>
-         <p>We cite a document with an anchor: <a href="#citation">... citation ...</a>.</p>
-      </part>
-   </control>
-   <control id="c3">
-      <title>Control C3</title>
-      <prop name="place">third</prop>
-      <part name="statement" id="c3-stmt">
-         <p>C3 ccccc cccccccccccccc.</p>
-      </part>
-   </control>
-   <back-matter>
-      <citation id="citation">
-         <desc>A citation to an out of line document.</desc>
-      </citation>
-   </back-matter>
+   <group>
+        <title>Group A of C</title>
+        <param id="param-A.a">
+            <label>A.a parameter</label>
+            <value>A.a value</value>
+        </param>
+        <control id="a1">
+            <title>Control A1</title>
+            <param id="param-a1.a">
+                <label>a1.a parameter</label>
+                <value>a1.a value</value>
+            </param>
+            <prop name="place">first</prop>
+            <part name="statement" id="a1-stmt">
+                <p>A1 aaaaa aaaaaaaaaa</p>
+                <p>Parameter A.a is set: <insert param-id="param-A.a"/></p>
+                <p>Parameter a1.a is set: <insert param-id="param-a1.a"/></p>
+                <p>Also, we <a href="#citation">refer to a citation</a>.</p>
+            </part>
+        </control>
+    </group>
+    <group>
+        <title>Group B of C</title>
+        <control id="b1">
+            <title>Control B1</title>
+            <prop name="place">first</prop>
+            <part name="statement" id="b1-stmt">
+                <p>B1 bbbb bbbbbbb.</p>
+            </part>
+        </control>
+    </group>
+    <group>
+        <title>Group C of C</title>
+        <control id="c1">
+            <title>Control C1</title>
+            <prop name="place">first</prop>
+            <part name="statement" id="c1-stmt">
+                <p>C1 ccccc ccc ccccccccccccccccc.</p>
+                <p>We cite a document with an anchor: <a href="#citation">... citation ...</a>.</p>
+            </part>
+        </control>
+        <control id="c3">
+            <title>Control C3</title>
+            <prop name="place">third</prop>
+            <part name="statement" id="c3-stmt">
+                <p>C3 ccccc cccccccccccccc.</p>
+            </part>
+            <control id="c3.a">
+                <title>Control C3-A</title>
+                <prop name="place">first</prop>
+                <part name="statement" id="c3-stmt">
+                    <p>C3 A ccccc cccccccccccccc.</p>
+                </part>
+                <control id="c3.a-1">
+                    <title>Control C3-A-1</title>
+                    <prop name="place">first</prop>
+                    <part name="statement" id="c3-stmt">
+                        <p>C3 A-1 ccccc cccccccccccccc.</p>
+                    </part>
+                </control>
+            </control>
+        </control>
+    </group>
+    <back-matter>
+        <citation id="citation">
+            <desc>A citation to an out of line document.</desc>
+        </citation>
+    </back-matter>
 </catalog>


### PR DESCRIPTION
# Committer Notes

The existing result can't be right - it doesn't match the schema (because `<param>` needs to be within a control or group, at least). 

This result is basically a full copy of the catalog, less controls `a2`, `a3, `b2`, `b3` and `c2`, and the unused `param-A.b`.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
