### PR TITLE
Update expected resolution result for exclude-call-test profile example

### DIFF
--- a/src/specifications/profile-resolution/profile-resolution-examples/output-expected/exclude-call-test_profile_RESOLVED.xml
+++ b/src/specifications/profile-resolution/profile-resolution-examples/output-expected/exclude-call-test_profile_RESOLVED.xml
@@ -9,74 +9,83 @@
       <prop name="resolution-timestamp">2019-12-10T15:21:20.296-05:00</prop>
       <link rel="resolution-source" href="../exclude-call-test_profile.xml">Test Profile</link>
    </metadata>
-   <control id="a2">
-      <title>Control A2</title>
-      <prop name="place">second</prop>
-      <part name="statement" id="a2-stmt">
-         <p>A2 aaa aaaaaaaaaa aaaaaaaaaaaaa</p>
-      </part>
-   </control>
-   <control id="a3">
-      <title>Control A3</title>
-      <prop name="place">third</prop>
-      <part name="statement" id="a3-stmt">
-         <p>A3 aaaaa aaaaaaaaaa</p>
-      </part>
-   </control>
-   <control id="b1">
-      <title>Control B1</title>
-      <prop name="place">first</prop>
-      <part name="statement" id="b1-stmt">
-         <p>B1 bbbb bbbbbbb.</p>
-      </part>
-   </control>
-   <control id="b2">
-      <title>Control B2</title>
-      <prop name="place">second</prop>
-      <part name="statement" id="b2-stmt">
-         <p>B2 bbb bbbbbbbbbbb bbbbbbbbbbbb.</p>
-      </part>
-   </control>
-   <control id="b3">
-      <title>Control B3</title>
-      <prop name="place">third</prop>
-      <part name="statement" id="b3-stmt">
-         <p>B3 bbbb bbbbbbb bbbb.</p>
-      </part>
-   </control>
-   <control id="c1">
-      <title>Control C1</title>
-      <prop name="place">first</prop>
-      <part name="statement" id="c1-stmt">
-         <p>C1 ccccc ccc ccccccccccccccccc.</p>
-      </part>
-   </control>
-   <control id="c2">
-      <title>Control C2</title>
-      <prop name="place">second</prop>
-      <part name="statement" id="c2-stmt">
-         <p>C2 cccccccc ccccccccccccccccc.</p>
-      </part>
-   </control>
-   <control id="c3">
-      <title>Control C3</title>
-      <prop name="place">third</prop>
-      <part name="statement" id="c3-stmt">
-         <p>C3 ccccc cccccccccccccc.</p>
-      </part>
-      <control id="c3.a">
-         <title>Control C3-A</title>
-         <prop name="place">first</prop>
-         <part name="statement" id="c3-stmt">
-            <p>C3 A ccccc cccccccccccccc.</p>
-         </part>
-         <control id="c3.a-1">
-            <title>Control C3-A-1</title>
-            <prop name="place">first</prop>
-            <part name="statement" id="c3-stmt">
-               <p>C3 A-1 ccccc cccccccccccccc.</p>
+   <group>
+        <title>Group A of C</title>
+        <control id="a2">
+            <title>Control A2</title>
+            <prop name="place">second</prop>
+            <part name="statement" id="a2-stmt">
+                <p>A2 aaa aaaaaaaaaa aaaaaaaaaaaaa</p>
             </part>
-         </control>
-      </control>
-   </control>
+        </control>
+        <control id="a3">
+            <title>Control A3</title>
+            <prop name="place">third</prop>
+            <part name="statement" id="a3-stmt">
+                <p>A3 aaaaa aaaaaaaaaa</p>
+            </part>
+        </control>
+    </group>
+    <group>
+        <title>Group B of C</title>
+        <control id="b1">
+            <title>Control B1</title>
+            <prop name="place">first</prop>
+            <part name="statement" id="b1-stmt">
+                <p>B1 bbbb bbbbbbb.</p>
+            </part>
+        </control>
+        <control id="b2">
+            <title>Control B2</title>
+            <prop name="place">second</prop>
+            <part name="statement" id="b2-stmt">
+                <p>B2 bbb bbbbbbbbbbb bbbbbbbbbbbb.</p>
+            </part>
+        </control>
+        <control id="b3">
+            <title>Control B3</title>
+            <prop name="place">third</prop>
+            <part name="statement" id="b3-stmt">
+                <p>B3 bbbb bbbbbbb bbbb.</p>
+            </part>
+        </control>
+    </group>
+    <group>
+        <title>Group C of C</title>
+        <control id="c1">
+            <title>Control C1</title>
+            <prop name="place">first</prop>
+            <part name="statement" id="c1-stmt">
+                <p>C1 ccccc ccc ccccccccccccccccc.</p>
+            </part>
+        </control>
+        <control id="c2">
+            <title>Control C2</title>
+            <prop name="place">second</prop>
+            <part name="statement" id="c2-stmt">
+                <p>C2 cccccccc ccccccccccccccccc.</p>
+            </part>
+        </control>
+        <control id="c3">
+            <title>Control C3</title>
+            <prop name="place">third</prop>
+            <part name="statement" id="c3-stmt">
+                <p>C3 ccccc cccccccccccccc.</p>
+            </part>
+            <control id="c3.a">
+                <title>Control C3-A</title>
+                <prop name="place">first</prop>
+                <part name="statement" id="c3-stmt">
+                    <p>C3 A ccccc cccccccccccccc.</p>
+                </part>
+                <control id="c3.a-1">
+                    <title>Control C3-A-1</title>
+                    <prop name="place">first</prop>
+                    <part name="statement" id="c3-stmt">
+                        <p>C3 A-1 ccccc cccccccccccccc.</p>
+                    </part>
+                </control>
+            </control>
+        </control>
+    </group>
 </catalog>


### PR DESCRIPTION
# Committer Notes

This is basically the entire catalog, except for the a1 profile.

The change adds the parent groups, and the children of c1.

### All Submissions:

- [X] Have you followed the guidelines in our [Contributing](https://github.com/usnistgov/OSCAL/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/usnistgov/OSCAL/pulls) for the same update/change?
- [X] Have you squashed any non-relevant commits and commit messages? \[[instructions](https://git-scm.com/book/en/v2/Git-Tools-Rewriting-History)\]
- [ ] Do all automated CI/CD checks pass?

### Changes to Core Features:

- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your core changes, as applicable?
- [ ] Have you included examples of how to use your new feature(s)?
- [ ] Have you updated all [OSCAL website](https://pages.nist.gov/OSCAL) and readme documentation affected by the changes you made? Changes to the OSCAL website can be made in the docs/content directory of your branch.
